### PR TITLE
make download path line up with extract path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: download
   get_url: url="{{ btsync_url[ansible_architecture] }}"
-           dest=/var/tmp/btsync.tgz
+           dest=/tmp/btsync.tar.gz
   register: download
 
 - name: extract


### PR DESCRIPTION
Great work with this! I did encounter a small bug where we download btsync to a different path than what we try to extract it from; this change ought to fix that.
