### PR TITLE
make api key an optional parameter

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -7,10 +7,12 @@
 "download_limit": 0,
 "upload_limit": 0,
 "webui": {
+    {% if btsync_webui.get(api_key) %}
+    "api_key"  : "{{ btsync_webui.api_key }}",
+    {% endif %}
     "listen": "0.0.0.0:8888",
     "login" : "{{ btsync_webui.user }}",
-    "password" : "{{ btsync_webui.password }}",
-    "api_key"  : "{{ btsync_webui.api_key }}"
+    "password" : "{{ btsync_webui.password }}"
 },
 "shared_folders": [
     {% for folder in btsync_shared_folders %}


### PR DESCRIPTION
Here's one more thing I'd like to change - I don't have an api key, but I'd like to be able to run the web ui nevertheless. This change should make it so that we only try passing an api key to the btsync config if the user specified it when adding the role. Haven't tested it yet though!
