### PR TITLE
ensure .sync directory exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,9 @@
 - name: activate service
   service: name=btsync enabled=yes
 
+- name: create .sync directory
+  file: path=/home/{{ btsync_user }}/.sync owner={{ btsync_user }} group={{ btsync_user }} mode=0700 state=directory
+
 - name: copy config
   template: src=config.json dest=/home/{{ btsync_user }}/.sync/ owner={{ btsync_user }} group={{ btsync_user }} mode=700
   notify: restart btsync


### PR DESCRIPTION
I was unable to use this role out of the box as the .sync directory in my btsync_user home directory did not exist.

Kindly let me know if I'm missing something obvious.
