### PR TITLE
allow specifying port to run on

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Install and manage a btsync server on Linux.
 
 # Role Variables
 
+**btsync_port**: Optional. Specify port to run on. Defaults to a random port at startup.
 **btsync_upnp**: Optional. Whether or not to use uPNP. True by default
 
 **btsync_user**: Required. The user who run the btsync daemon.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ btsync_url:
 btsync_upnp: true
 btsync_webui:
   - listen: 0.0.0.0
+btsync_port: 0

--- a/templates/config.json
+++ b/templates/config.json
@@ -1,6 +1,6 @@
 {
 "device_name": "btsync_{{ btsync_user }}",
-"listening_port": 0,
+"listening_port": {{ btsync_port }},
 "storage_path": "/home/{{ btsync_user }}/.sync",
 "check_for_updates": false,
 "use_upnp": {% if btsync_upnp %}true{% else %}false{% endif %},


### PR DESCRIPTION
Does what it says on the tin. I find this to be handy when predefining a host over a VPN.